### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Kurento Toolbox for iOS
 [![Build Status](https://travis-ci.org/nubomediaTI/Kurento-iOS.svg?branch=master)](https://travis-ci.org/nubomediaTI/Kurento-iOS)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/KurentoToolbox.svg)](https://img.shields.io/cocoapods/v/KurentoToolbox.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/KurentoToolbox.svg)](https://img.shields.io/cocoapods/v/KurentoToolbox.svg)
 [![Platform](https://img.shields.io/cocoapods/p/KurentoToolbox.svg?style=flat)](http://cocoadocs.org/docsets/KurentoToolbox)
 [![License](https://img.shields.io/cocoapods/l/KurentoToolbox.svg)](https://img.shields.io/cocoapods/l/KurentoToolbox.svg)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
